### PR TITLE
nextLink usage with graph.microsoft.com

### DIFF
--- a/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
+++ b/src/main/java/org/almrangers/auth/aad/AadIdentityProvider.java
@@ -180,7 +180,8 @@ public class AadIdentityProvider implements OAuth2IdentityProvider {
 	  String url =  String.format(settings.getGraphMembershipUrl(), settings.tenantId(), userId);
 	  // Append odata query parameters for subsequent pages
 	if (null != nextPage) {
-		url += "&" + nextPage;
+		// url += "&" + nextPage;
+		url = nextPage
 	}
 	return new URL(url);
   }


### PR DESCRIPTION
absolute nextLink to be used when using graph.microsoft.com

with graph.windows.net, nextLink token was to be appended in the original url